### PR TITLE
Add build wired for local testnet

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,12 +34,12 @@ jobs:
         run: npm ci
 
       - name: Build static site
-        run: npm run build
+        run: npm run build:pages
 
       - name: Upload static site
         uses: actions/upload-pages-artifact@v3
         with:
-          path: dist
+          path: _site
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+_site
 *.tsbuildinfo
 *.local
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Pubky Explorer
 
-https://explorer.pubky.app (wired for a testnet running on your localhost: https://explorer.pubky.app/testnet/)
+https://explorer.pubky.app
+
+## Local testnet
+
+https://explorer.pubky.app/testnet/ connects to a Pubky testnet running on your machine. Start the
+local PKARR relay on port `15411` and at least one homeserver before using it.
 
 ## Usage
 
@@ -28,6 +33,16 @@ It correctly bundles Solid in production mode and optimizes the build for the be
 
 The build is minified and the filenames include the hashes.<br>
 Your app is ready to be deployed!
+
+### `npm run build:pages`
+
+Builds the mainnet and local testnet versions for GitHub Pages in `_site` and `_site/testnet`.
+
+### `npm run preview:pages`
+
+Previews the output of `npm run build:pages` locally.<br>
+Open [http://localhost:4173](http://localhost:4173) for mainnet or
+[http://localhost:4173/testnet/](http://localhost:4173/testnet/) for the local testnet.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pubky Explorer
 
-https://explorer.pubky.app
+https://explorer.pubky.app (wired for a testnet running on your localhost: https://explorer.pubky.app/testnet/)
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "start": "vite",
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "build:pages": "npm run build -- --base ./ --outDir _site && VITE_TESTNET=true npm run build -- --base ./ --outDir _site/testnet",
+    "build:pages": "npm run build -- --base ./ --outDir _site && VITE_TESTNET=true npm run build -- --base /testnet/ --outDir _site/testnet",
     "preview": "vite preview",
-    "preview:pages": "vite preview --outDir _site"
+    "preview:pages": "vite preview --mode pages --outDir _site"
   },
   "dependencies": {
     "@synonymdev/pubky": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "start": "vite",
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "build:pages": "npm run build -- --base ./ --outDir _site && VITE_TESTNET=true npm run build -- --base ./ --outDir _site/testnet",
+    "preview": "vite preview",
+    "preview:pages": "vite preview --outDir _site"
   },
   "dependencies": {
     "@synonymdev/pubky": "^0.6.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import "./css/App.css";
 import { Explorer } from "./Explorer.tsx";
 import { Spinner } from "./Spinner.tsx";
 import { ShareButton } from "./ShareButton";
+import { TestnetBanner } from "./TestnetBanner";
 import { Show, createSignal, onMount, onCleanup, createEffect } from "solid-js";
 import {
   store,
@@ -14,6 +15,7 @@ import {
   openPreview,
   closePreview,
   formatDisplayPath,
+  IS_TESTNET,
   isPubkeySegment,
   stripInputPrefixes,
 } from "./state.ts";
@@ -70,6 +72,9 @@ function App() {
   return (
     <>
       <Spinner />
+      <Show when={IS_TESTNET}>
+        <TestnetBanner />
+      </Show>
       <div class="head">
         <div>
           <a href="https://pubky.app" target="_blank" rel="noopener noreferrer">

--- a/src/TestnetBanner.tsx
+++ b/src/TestnetBanner.tsx
@@ -1,6 +1,6 @@
 import { For, createSignal, onCleanup, onMount } from "solid-js";
 
-type ServiceStatus = "checking" | "connected" | "disconnected";
+type ServiceStatus = "checking" | "reachable" | "no-response";
 
 type LocalService = {
   name: string;
@@ -109,16 +109,16 @@ async function probeService(service: LocalService): Promise<ServiceStatus> {
       credentials: "omit",
       signal: controller.signal,
     });
-    return "connected";
+    return "reachable";
   } catch {
-    return "disconnected";
+    return "no-response";
   } finally {
     window.clearTimeout(timeout);
   }
 }
 
 function statusLabel(status: ServiceStatus): string {
-  if (status === "connected") return "Connected";
-  if (status === "disconnected") return "Unavailable";
+  if (status === "reachable") return "Reachable";
+  if (status === "no-response") return "No repsonse";
   return "Checking";
 }

--- a/src/TestnetBanner.tsx
+++ b/src/TestnetBanner.tsx
@@ -14,11 +14,6 @@ const LOCAL_SERVICES: LocalService[] = [
     port: 15411,
     url: "http://localhost:15411/",
   },
-  {
-    name: "Homeserver",
-    port: 6286,
-    url: "http://localhost:6286/",
-  },
 ];
 
 const PROBE_INTERVAL_MS = 15_000;

--- a/src/TestnetBanner.tsx
+++ b/src/TestnetBanner.tsx
@@ -1,0 +1,124 @@
+import { For, createSignal, onCleanup, onMount } from "solid-js";
+
+type ServiceStatus = "checking" | "connected" | "disconnected";
+
+type LocalService = {
+  name: string;
+  port: number;
+  url: string;
+};
+
+const LOCAL_SERVICES: LocalService[] = [
+  {
+    name: "PKARR relay",
+    port: 15411,
+    url: "http://localhost:15411/",
+  },
+  {
+    name: "Homeserver",
+    port: 6286,
+    url: "http://localhost:6286/",
+  },
+];
+
+const PROBE_INTERVAL_MS = 15_000;
+const PROBE_TIMEOUT_MS = 4_000;
+
+export function TestnetBanner() {
+  const [statuses, setStatuses] = createSignal<Record<number, ServiceStatus>>(
+    Object.fromEntries(
+      LOCAL_SERVICES.map((service) => [service.port, "checking"]),
+    ),
+  );
+
+  let probeActive = false;
+
+  async function probeServices() {
+    if (probeActive || document.visibilityState === "hidden") return;
+    probeActive = true;
+
+    try {
+      await Promise.all(
+        LOCAL_SERVICES.map(async (service) => {
+          const status = await probeService(service);
+          setStatuses((current) => ({
+            ...current,
+            [service.port]: status,
+          }));
+        }),
+      );
+    } finally {
+      probeActive = false;
+    }
+  }
+
+  onMount(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") void probeServices();
+    };
+    const interval = window.setInterval(
+      () => void probeServices(),
+      PROBE_INTERVAL_MS,
+    );
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    void probeServices();
+
+    onCleanup(() => {
+      window.clearInterval(interval);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    });
+  });
+
+  return (
+    <aside class="testnet-banner" aria-label="Local testnet status">
+      <strong class="testnet-banner-title">Local testnet</strong>
+      <ul class="testnet-services" aria-live="polite">
+        <For each={LOCAL_SERVICES}>
+          {(service) => {
+            const status = () => statuses()[service.port] ?? "checking";
+            return (
+              <li
+                class={`testnet-service ${status()}`}
+                aria-label={`${service.name} on localhost:${service.port}: ${statusLabel(status())}`}
+              >
+                <i aria-hidden="true" />
+                <span>
+                  {service.name} · localhost:{service.port}
+                </span>
+                <strong>{statusLabel(status())}</strong>
+              </li>
+            );
+          }}
+        </For>
+      </ul>
+    </aside>
+  );
+}
+
+async function probeService(service: LocalService): Promise<ServiceStatus> {
+  const controller = new AbortController();
+  const timeout = window.setTimeout(
+    () => controller.abort(),
+    PROBE_TIMEOUT_MS,
+  );
+
+  try {
+    await fetch(service.url, {
+      cache: "no-store",
+      credentials: "omit",
+      signal: controller.signal,
+    });
+    return "connected";
+  } catch {
+    return "disconnected";
+  } finally {
+    window.clearTimeout(timeout);
+  }
+}
+
+function statusLabel(status: ServiceStatus): string {
+  if (status === "connected") return "Connected";
+  if (status === "disconnected") return "Unavailable";
+  return "Checking";
+}

--- a/src/TestnetBanner.tsx
+++ b/src/TestnetBanner.tsx
@@ -114,6 +114,6 @@ async function probeService(service: LocalService): Promise<ServiceStatus> {
 
 function statusLabel(status: ServiceStatus): string {
   if (status === "reachable") return "Reachable";
-  if (status === "no-response") return "No repsonse";
+  if (status === "no-response") return "No response";
   return "Checking";
 }

--- a/src/css/App.css
+++ b/src/css/App.css
@@ -81,13 +81,13 @@
   font-size: inherit;
 }
 
-.testnet-service.connected strong,
-.testnet-service.connected i {
+.testnet-service.reachable strong,
+.testnet-service.reachable i {
   color: #4ade80;
 }
 
-.testnet-service.disconnected strong,
-.testnet-service.disconnected i {
+.testnet-service.no-response strong,
+.testnet-service.no-response i {
   color: #fca5a5;
 }
 

--- a/src/css/App.css
+++ b/src/css/App.css
@@ -11,6 +11,99 @@
   flex-direction: column;
 }
 
+.testnet-banner {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: flex;
+  align-self: center;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  box-sizing: border-box;
+  width: 100vw;
+  margin-top: -2rem;
+  margin-bottom: 1rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 2px solid #7c2d12;
+  background: #f97316;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  color: #1c0a00;
+  font-size: 0.9rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.testnet-banner-title {
+  flex: 0 0 auto;
+}
+
+.testnet-services {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: center;
+  gap: 0.5rem;
+  width: auto;
+  max-width: 100%;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.testnet-service {
+  display: inline-flex;
+  width: auto;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(28, 10, 0, 0.72);
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.testnet-service i {
+  width: 0.55rem;
+  height: 0.55rem;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 0.45rem currentColor;
+}
+
+.testnet-service strong {
+  font-size: inherit;
+}
+
+.testnet-service.connected strong,
+.testnet-service.connected i {
+  color: #4ade80;
+}
+
+.testnet-service.disconnected strong,
+.testnet-service.disconnected i {
+  color: #fca5a5;
+}
+
+.testnet-service.checking strong,
+.testnet-service.checking i {
+  color: #fde68a;
+}
+
+@media (max-width: 600px) {
+  .testnet-banner {
+    flex-direction: column;
+    gap: 0.45rem;
+    padding-block: 0.6rem;
+  }
+}
+
 .head {
   position: relative;
   width: 100%;

--- a/src/state.ts
+++ b/src/state.ts
@@ -2,8 +2,8 @@ import { Pubky } from "@synonymdev/pubky";
 import type { Address } from "@synonymdev/pubky";
 import { createStore } from "solid-js/store";
 
-export const pubky =
-  import.meta.env.VITE_TESTNET === "true" ? Pubky.testnet() : new Pubky();
+export const IS_TESTNET = import.meta.env.VITE_TESTNET === "true";
+export const pubky = IS_TESTNET ? Pubky.testnet() : new Pubky();
 const publicStorage = pubky.publicStorage;
 
 export type ListItem = { link: string; name: string; isDirectory: boolean };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,35 @@
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import solid from "vite-plugin-solid";
 
-export default defineConfig({
-  plugins: [solid()],
-});
+function pagesPreviewFallback(): Plugin {
+  return {
+    name: "pages-preview-fallback",
+    configurePreviewServer(server) {
+      server.middlewares.use((request, _response, next) => {
+        const previewRequest = request as unknown as {
+          method?: string;
+          url?: string;
+          headers: { accept?: string | string[] };
+        };
+
+        if (
+          (previewRequest.method === "GET" ||
+            previewRequest.method === "HEAD") &&
+          previewRequest.url?.startsWith("/testnet/") &&
+          previewRequest.headers.accept?.includes("text/html")
+        ) {
+          const queryIndex = previewRequest.url.indexOf("?");
+          const query =
+            queryIndex === -1 ? "" : previewRequest.url.slice(queryIndex);
+          previewRequest.url = `/testnet/index.html${query}`;
+        }
+
+        next();
+      });
+    },
+  };
+}
+
+export default defineConfig(({ mode }) => ({
+  plugins: [solid(), mode === "pages" && pagesPreviewFallback()],
+}));


### PR DESCRIPTION
- Add a new build so you can access your local testnet environment to inspect the data on your local homeserver. Just open the website and you're good to go.
- Adds a persistent testnet banner with live PKARR relay and Homeserver status.

<img width="1004" height="682" alt="Selection_192" src="https://github.com/user-attachments/assets/cacf02bb-67ba-41ec-8b96-93ad560e3a89" />

## Testing

With a local testnet running on the default ports:

1. Create and authorize a local identity using the [Pubky Ring Simulator](https://simulator.pubkyring.app/).
2. Create data with the [Basic Pubky App template](https://pubky.github.io/pubky-app-templates/testnet/basic-pubky-app/).
3. Run `npm run build:pages` and `npm run preview:pages`, then browse the data at [http://localhost:4173/testnet/](http://localhost:4173/testnet/). --> once merged, just open https://explorer.pubky.app/testnet/